### PR TITLE
Add new CLI flag to exclude sources from elements

### DIFF
--- a/superflore/generators/buildstream/gen_packages.py
+++ b/superflore/generators/buildstream/gen_packages.py
@@ -33,7 +33,8 @@ org = "Open Source Robotics Foundation"
 
 def regenerate_pkg(
     overlay, pkg, rosdistro, preserve_existing, srcrev_cache,
-    skip_keys, external_repos, generated_elements_dir = "elements/generated"
+    skip_keys, external_repos, generated_elements_dir = "elements/generated",
+    exclude_source=False,
 ):
     pkg_names = get_package_names(rosdistro)[0]
     if pkg not in pkg_names:
@@ -96,7 +97,8 @@ def regenerate_pkg(
         overlay.repo.remove_file(existing, True)
     try:
         current = bst_element(
-            rosdistro, pkg, srcrev_cache, skip_keys, repo_dir, external_repos
+            rosdistro, pkg, srcrev_cache, skip_keys, repo_dir, external_repos,
+            exclude_source=exclude_source,
         )
     except InvalidPackage as e:
         err('Invalid package: ' + str(e))
@@ -141,7 +143,9 @@ def regenerate_pkg(
 
 def _gen_element_for_package(
     rosdistro, pkg_name, pkg, repo, ros_pkg,
-    pkg_rosinstall, srcrev_cache, skip_keys, repo_dir, external_repos
+    pkg_rosinstall, srcrev_cache, skip_keys, repo_dir, external_repos,
+    *,
+    exclude_source,
 ):
     pkg_names = get_package_names(rosdistro)
     pkg_dep_walker = DependencyWalker(rosdistro)
@@ -170,6 +174,7 @@ def _gen_element_for_package(
         skip_keys,
         repo_dir,
         external_repos,
+        exclude_source=exclude_source,
     )
     # add build dependencies
     for bdep in pkg_build_deps:
@@ -196,7 +201,9 @@ def _gen_element_for_package(
 
 class bst_element(object):
     def __init__(
-        self, rosdistro, pkg_name, srcrev_cache, skip_keys, repo_dir, external_repos
+        self, rosdistro, pkg_name, srcrev_cache, skip_keys, repo_dir, external_repos,
+        *,
+        exclude_source,
     ):
         pkg = rosdistro.release_packages[pkg_name]
         repo = rosdistro.repositories[pkg.repository_name].release_repository
@@ -208,7 +215,8 @@ class bst_element(object):
 
         self.element = _gen_element_for_package(
             rosdistro, pkg_name, pkg, repo, ros_pkg, pkg_rosinstall,
-            srcrev_cache, skip_keys, repo_dir, external_repos
+            srcrev_cache, skip_keys, repo_dir, external_repos,
+            exclude_source=exclude_source,
         )
 
     def element_text(self):

--- a/superflore/generators/buildstream/run.py
+++ b/superflore/generators/buildstream/run.py
@@ -75,6 +75,12 @@ def main():
             default="elements/generated",
             help='directory for generated bst elements',
             type=str)
+    parser.add_argument(
+            '--exclude-sources-for',
+            default=[],
+            nargs='+',
+            help='do not generate sources for the specified packages',
+            type=str)
     args = parser.parse_args(sys.argv[1:])
     pr_comment = args.pr_comment
     skip_keys = set(args.skip_keys) if args.skip_keys else set()
@@ -146,6 +152,7 @@ def main():
             if args.only:
                 distro = get_distro(args.ros_distro)
                 packages = args.only
+                exclude_sources_for = args.exclude_sources_for
                 include_dependencies = True
                 if include_dependencies:
                     packages = set(packages) | \
@@ -165,6 +172,7 @@ def main():
                             srcrev_cache,
                             skip_keys=skip_keys,
                             external_repos=external_repos,
+                            exclude_source=pkg in exclude_sources_for
                         )
                     except KeyError:
                         err("No package to satisfy key '%s' available "


### PR DESCRIPTION
For some buildstream elements generated by superflore we do not want to use the normal source. The way that buildstream includes work means it is not possible to overrite element sources.

This commit allows users of superflore-gen-bst to explicitly leave the `sources` of an element blank so that the sources can be specified by an include file.