### PR TITLE
Add flag to also add build-dep for runtime-depends

### DIFF
--- a/superflore/generators/buildstream/gen_packages.py
+++ b/superflore/generators/buildstream/gen_packages.py
@@ -35,6 +35,7 @@ def regenerate_pkg(
     overlay, pkg, rosdistro, preserve_existing, srcrev_cache,
     skip_keys, external_repos, generated_elements_dir = "elements/generated",
     exclude_source=False,
+    runtime_as_build_dependencies=False,
 ):
     pkg_names = get_package_names(rosdistro)[0]
     if pkg not in pkg_names:
@@ -99,6 +100,7 @@ def regenerate_pkg(
         current = bst_element(
             rosdistro, pkg, srcrev_cache, skip_keys, repo_dir, external_repos,
             exclude_source=exclude_source,
+            runtime_as_build_dependencies=runtime_as_build_dependencies,
         )
     except InvalidPackage as e:
         err('Invalid package: ' + str(e))
@@ -146,6 +148,7 @@ def _gen_element_for_package(
     pkg_rosinstall, srcrev_cache, skip_keys, repo_dir, external_repos,
     *,
     exclude_source,
+    runtime_as_build_dependencies,
 ):
     pkg_names = get_package_names(rosdistro)
     pkg_dep_walker = DependencyWalker(rosdistro)
@@ -175,6 +178,7 @@ def _gen_element_for_package(
         repo_dir,
         external_repos,
         exclude_source=exclude_source,
+        runtime_as_build_dependencies=runtime_as_build_dependencies,
     )
     # add build dependencies
     for bdep in pkg_build_deps:
@@ -204,6 +208,7 @@ class bst_element(object):
         self, rosdistro, pkg_name, srcrev_cache, skip_keys, repo_dir, external_repos,
         *,
         exclude_source,
+        runtime_as_build_dependencies,
     ):
         pkg = rosdistro.release_packages[pkg_name]
         repo = rosdistro.repositories[pkg.repository_name].release_repository
@@ -217,6 +222,7 @@ class bst_element(object):
             rosdistro, pkg_name, pkg, repo, ros_pkg, pkg_rosinstall,
             srcrev_cache, skip_keys, repo_dir, external_repos,
             exclude_source=exclude_source,
+            runtime_as_build_dependencies=runtime_as_build_dependencies,
         )
 
     def element_text(self):

--- a/superflore/generators/buildstream/run.py
+++ b/superflore/generators/buildstream/run.py
@@ -76,6 +76,11 @@ def main():
             help='directory for generated bst elements',
             type=str)
     parser.add_argument(
+            '--runtime-as-build-dependencies',
+            default=False,
+            action='store_true',
+            help='Generate a build-dependency for exported dependencies as well as a runtime-dependency')
+    parser.add_argument(
             '--exclude-sources-for',
             default=[],
             nargs='+',
@@ -153,6 +158,7 @@ def main():
                 distro = get_distro(args.ros_distro)
                 packages = args.only
                 exclude_sources_for = args.exclude_sources_for
+                runtime_as_build_dependencies = args.runtime_as_build_dependencies
                 include_dependencies = True
                 if include_dependencies:
                     packages = set(packages) | \
@@ -172,7 +178,8 @@ def main():
                             srcrev_cache,
                             skip_keys=skip_keys,
                             external_repos=external_repos,
-                            exclude_source=pkg in exclude_sources_for
+                            exclude_source=pkg in exclude_sources_for,
+                            runtime_as_build_dependencies=runtime_as_build_dependencies,
                         )
                     except KeyError:
                         err("No package to satisfy key '%s' available "


### PR DESCRIPTION
Superflore  is correct to generate runtime dependencies when an
dependency is needed to provide headers and libraries needed to consume
an element but not to build it. Some tooling struggles to interpret the
c/c++ dependency graph when the dependencies are represented as
runtime-dependencies.

This commit adds a flag to additionally generate a build-dependency
for elements that depend on a ROS package that defines a package as
a runtime dependency.
