### PR TITLE
Use git-describe format in generated ref

### DIFF
--- a/superflore/generators/buildstream/bst_element.py
+++ b/superflore/generators/buildstream/bst_element.py
@@ -329,7 +329,7 @@ class BstElement(object):
         source["kind"] = "git_repo"
         source["url"] = self.get_repo_src_uri()
         source["track"] = self.get_repo_branch_name()
-        source["ref"] = self.srcrev
+        source["ref"] = "%s-g%s" % (self.get_repo_tag_name(), self.srcrev)
         sources.append(source)
 
         if self.exclude_source:


### PR DESCRIPTION
Use the git-describe format for the ref inline with the `git_repo`[^1] source plugin. This allows the plugin to report the version as `SourceInfo`[^2].

[^1]: See <https://buildstream.gitlab.io/buildstream-plugins-community/sources/git_repo.html>.
[^2]: See <https://docs.buildstream.build/master/buildstream.source.html#buildstream.source.SourceInfo>.