### PR TITLE
Allow tweaking the cmake flags in an .inc file

### DIFF
--- a/superflore/generators/buildstream/bst_element.py
+++ b/superflore/generators/buildstream/bst_element.py
@@ -348,6 +348,13 @@ class BstElement(object):
                     if listkey in include and listkey in element:
                         # Append generated list to list from include file
                         element[listkey] = {"(<)": element[listkey]}
+
+                if "cmake-extra" in include.get("variables", {}):
+                    if "variables" not in element:
+                        element["variables"] = {}
+
+                    element["variables"]["cmake-local"] = "%{cmake-extra} " + element["variables"].get("cmake-local", "")
+
                 # BuildStream include directive
                 element["(@)"] = includepath
 


### PR DESCRIPTION
If the .inc file defines the `cmake-extra` variable the element will include the value of that variable in its `cmake-local definition`.